### PR TITLE
Add support for uuid type in binary copy client

### DIFF
--- a/src/Allegro.Extensions.Dapper/Allegro.Extensions.Dapper.Postgres/Abstractions/DbType.cs
+++ b/src/Allegro.Extensions.Dapper/Allegro.Extensions.Dapper.Postgres/Abstractions/DbType.cs
@@ -9,5 +9,6 @@ public enum DbType
     BigInt,
     Text,
     Date,
-    Decimal
+    Decimal,
+    Guid,
 }

--- a/src/Allegro.Extensions.Dapper/Allegro.Extensions.Dapper.Postgres/DapperPostgresBinaryCopyClient.cs
+++ b/src/Allegro.Extensions.Dapper/Allegro.Extensions.Dapper.Postgres/DapperPostgresBinaryCopyClient.cs
@@ -65,6 +65,7 @@ internal class DapperPostgresBinaryCopyClient : IDapperPostgresBinaryCopyClient
             DbType.Text => NpgsqlDbType.Text,
             DbType.Date => NpgsqlDbType.Date,
             DbType.Decimal => NpgsqlDbType.Numeric,
+            DbType.Guid => NpgsqlDbType.Uuid,
             _ => throw new ArgumentOutOfRangeException(nameof(dbType), dbType, "Unknown type")
         };
     }


### PR DESCRIPTION
[Npgsql natively supports mapping between .NET `Guid` type and PostgreSQL `uuid` type](https://www.npgsql.org/doc/types/basic.html#read-mappings). This change allows us to use that support in our Binary Copy Client class.