### PR TITLE
Remove assembly naming convention from AddStronglyTypedIds

### DIFF
--- a/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.AspNetCore/Swagger/StronglyTypedIdsSwaggerExtensions.cs
+++ b/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.AspNetCore/Swagger/StronglyTypedIdsSwaggerExtensions.cs
@@ -13,8 +13,6 @@ namespace Allegro.Extensions.Identifiers.AspNetCore.Swagger;
 /// </summary>
 public static class StronglyTypedIdsSwaggerExtensions
 {
-    private const string IdentifiersAssemblyNameSuffix = "Identifiers";
-
     /// <summary>
     /// Add swagger support for strongly typed identifiers
     /// </summary>
@@ -23,7 +21,7 @@ public static class StronglyTypedIdsSwaggerExtensions
         services.Configure<SwaggerGenOptions>(options =>
         {
             var types = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(x => x.FullName != null && x.FullName.Contains(IdentifiersAssemblyNameSuffix))
+                .Where(x => x.FullName != null)
                 .SelectMany(x => x.GetTypes())
                 .Where(x => IsAssignableToGenericType(x, typeof(IStronglyTypedId<>)) && !x.IsInterface && !x.IsAbstract)
                 .ToList();

--- a/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.AspNetCore/Swagger/StronglyTypedIdsSwaggerExtensions.cs
+++ b/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.AspNetCore/Swagger/StronglyTypedIdsSwaggerExtensions.cs
@@ -21,7 +21,6 @@ public static class StronglyTypedIdsSwaggerExtensions
         services.Configure<SwaggerGenOptions>(options =>
         {
             var types = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(x => x.FullName != null)
                 .SelectMany(x => x.GetTypes())
                 .Where(x => IsAssignableToGenericType(x, typeof(IStronglyTypedId<>)) && !x.IsInterface && !x.IsAbstract)
                 .ToList();

--- a/src/Allegro.Extensions.Identifiers/CHANGELOG.md
+++ b/src/Allegro.Extensions.Identifiers/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2022-11-15
+
+### Changed
+
+* Updated AddStronglyTypedIds to remove assembly naming convention used for Swagger mapping configuration.
+
 ## [1.0.0] - 2022-05-26
 
 ### Added

--- a/src/Allegro.Extensions.Identifiers/version.xml
+++ b/src/Allegro.Extensions.Identifiers/version.xml
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Updated `AddStronglyTypedIds` to remove assembly naming convention used for Swagger mapping configuration.
- Bump version of `Allegro.Extensions.Identifiers.AspNetCore` 1.1.0