### PR TITLE
Fix/stick to generator version

### DIFF
--- a/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.Abstractions/Allegro.Extensions.Identifiers.Abstractions.csproj
+++ b/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.Abstractions/Allegro.Extensions.Identifiers.Abstractions.csproj
@@ -27,6 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Meziantou.Framework.StronglyTypedId" Version="1.0.22" />
+    <PackageReference Include="Meziantou.Framework.StronglyTypedId" Version="[1.0.22]" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="[4.2.0]"/>
   </ItemGroup>
 </Project>

--- a/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.Demo/Allegro.Extensions.Identifiers.Demo.csproj
+++ b/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.Demo/Allegro.Extensions.Identifiers.Demo.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="1.5.1">

--- a/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.Demo/Allegro.Extensions.Identifiers.Demo.csproj
+++ b/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.Demo/Allegro.Extensions.Identifiers.Demo.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsyncFixer" Version="1.5.1">

--- a/src/Allegro.Extensions.Identifiers/CHANGELOG.md
+++ b/src/Allegro.Extensions.Identifiers/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2023-01-03
+
+### Fix
+
+* Stick to version 1.0.22 of Meziantou.Framework.StronglyTypedId as higher versions introduces some errors: https://github.com/meziantou/Meziantou.Framework/issues/507
+
 ## [1.1.0] - 2022-11-15
 
 ### Changed

--- a/src/Allegro.Extensions.Identifiers/version.xml
+++ b/src/Allegro.Extensions.Identifiers/version.xml
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Stick to version 1.0.22 of Meziantou.Framework.StronglyTypedId as higher versions introduces some errors: https://github.com/meziantou/Meziantou.Framework/issues/507