### PR TITLE
Feature/improve assembly scanning

### DIFF
--- a/src/Allegro.Extensions.DependencyCall/Allegro.Extensions.DependencyCall/StartupExtensions.cs
+++ b/src/Allegro.Extensions.DependencyCall/Allegro.Extensions.DependencyCall/StartupExtensions.cs
@@ -25,9 +25,7 @@ public static class StartupExtensions
             s => s
                 .FromAssemblies(
                     applicationAssemblies ??
-                    AppDomain.CurrentDomain.GetAssemblies()
-                        // Filter microsoft assemblies due to reflection problems in Microsoft.Data.SqlClient
-                        .Where(a => a.FullName?.StartsWith("Microsoft", StringComparison.Ordinal) != true))
+                    AppDomain.CurrentDomain.GetAssemblies())
                 .AddClasses(c => c.AssignableTo(typeof(IDependencyCall<,>)))
                 .AsImplementedInterfaces()// TODO: remove scrutor and register by own util
                 .WithTransientLifetime());

--- a/src/Allegro.Extensions.DependencyCall/version.xml
+++ b/src/Allegro.Extensions.DependencyCall/version.xml
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.AspNetCore/Swagger/StronglyTypedIdsSwaggerExtensions.cs
+++ b/src/Allegro.Extensions.Identifiers/Allegro.Extensions.Identifiers.AspNetCore/Swagger/StronglyTypedIdsSwaggerExtensions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Allegro.Extensions.Identifiers.Abstractions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Any;
@@ -14,12 +15,13 @@ public static class StronglyTypedIdsSwaggerExtensions
     /// <summary>
     /// Add swagger support for strongly typed identifiers
     /// </summary>
-    public static IServiceCollection AddStronglyTypedIds(this IServiceCollection services)
+    public static IServiceCollection AddStronglyTypedIds(
+        this IServiceCollection services,
+        IReadOnlyCollection<Assembly>? applicationAssemblies = null)
     {
         services.Configure<SwaggerGenOptions>(options =>
         {
-            var types = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(a => a.FullName?.StartsWith("Microsoft", StringComparison.Ordinal) != true)
+            var types = (applicationAssemblies ?? AppDomain.CurrentDomain.GetAssemblies())
                 .SelectMany(x => x.GetTypes())
                 .Where(x => IsAssignableToGenericType(x, typeof(IStronglyTypedId<>)) && !x.IsInterface && !x.IsAbstract)
                 .ToList();

--- a/src/Allegro.Extensions.Identifiers/version.xml
+++ b/src/Allegro.Extensions.Identifiers/version.xml
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Removed .Where(a => a.FullName?.StartsWith("Microsoft", StringComparison.Ordinal) != true)) from dependency calls startup extension, as it's possible to pass assembly list from client library, and problems with sql had came from clients, not the DC lib
- Added IReadOnlyCollection<Assembly>? applicationAssemblies = null to StronglyTypedIdsSwaggerExtension. AddStronglyTypedIds, so similar assembly list can be passed