### PR TITLE
Fix AddClasses usages to explicitly pass publicOnly parameter

### DIFF
--- a/src/Allegro.Extensions.Cqrs/Allegro.Extensions.Cqrs.FluentValidations/StartupExtensions.cs
+++ b/src/Allegro.Extensions.Cqrs/Allegro.Extensions.Cqrs.FluentValidations/StartupExtensions.cs
@@ -16,16 +16,22 @@ public static class StartupExtensions
     /// </summary>
     /// <param name="services"></param>
     /// <param name="assemblies">Assembly collection in which IValidators should be looked for.</param>
-    public static IServiceCollection AddCqrsFluentValidations(this IServiceCollection services, IEnumerable<Assembly> assemblies)
+    /// <param name="publicOnly">Determines whether only public classes should be registered</param>
+    public static IServiceCollection AddCqrsFluentValidations(
+        this IServiceCollection services,
+        IEnumerable<Assembly> assemblies,
+        bool publicOnly = false)
     {
         services.Scan(s => s.FromAssemblies(assemblies)
-            .AddClasses(c => c.AssignableTo(typeof(IValidator<>)))
+            .AddClasses(c => c.AssignableTo(typeof(IValidator<>)), publicOnly)
             .AsImplementedInterfaces()
             .WithScopedLifetime());
 
         services
             .Scan(s => s.FromCallingAssembly()
-                .AddClasses(c => c.AssignableToAny(typeof(ICommandValidator<>), typeof(IQueryValidator<>)))
+                .AddClasses(
+                    c => c.AssignableToAny(typeof(ICommandValidator<>), typeof(IQueryValidator<>)),
+                    publicOnly)
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
 

--- a/src/Allegro.Extensions.Cqrs/Allegro.Extensions.Cqrs/Commands/StartupExtensions.cs
+++ b/src/Allegro.Extensions.Cqrs/Allegro.Extensions.Cqrs/Commands/StartupExtensions.cs
@@ -15,20 +15,26 @@ public static class StartupExtensions
     /// </summary>
     /// <param name="services"></param>
     /// <param name="assemblies">Assembly collection in which Command related types should be looked for.</param>
-    public static IServiceCollection AddCommands(this IServiceCollection services, IEnumerable<Assembly> assemblies)
+    /// <param name="publicOnly">Determines whether only public classes should be registered</param>
+    public static IServiceCollection AddCommands(
+        this IServiceCollection services,
+        IEnumerable<Assembly> assemblies,
+        bool publicOnly = false)
     {
         services
             .AddSingleton<ICommandDispatcher, CommandDispatcher>();
         services
             .Scan(s => s.FromAssemblies(assemblies) // TODO: should we remove Scrutor in future?
-                .AddClasses(c => c.AssignableTo(typeof(ICommandHandler<>))
-                    .WithoutAttribute<DecoratorAttribute>())
+                .AddClasses(
+                    c => c.AssignableTo(typeof(ICommandHandler<>))
+                        .WithoutAttribute<DecoratorAttribute>(),
+                    publicOnly)
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
 
         services
             .Scan(s => s.FromAssemblies(assemblies)
-                .AddClasses(c => c.AssignableTo(typeof(ICommandValidator<>)))
+                .AddClasses(c => c.AssignableTo(typeof(ICommandValidator<>)), publicOnly)
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
         return services;

--- a/src/Allegro.Extensions.Cqrs/Allegro.Extensions.Cqrs/Queries/StartupExtensions.cs
+++ b/src/Allegro.Extensions.Cqrs/Allegro.Extensions.Cqrs/Queries/StartupExtensions.cs
@@ -15,18 +15,21 @@ public static class StartupExtensions
     /// </summary>
     /// <param name="services"></param>
     /// <param name="assemblies">Assembly collection in which Command related types should be looked for.</param>
-    public static IServiceCollection AddQueries(this IServiceCollection services, IEnumerable<Assembly> assemblies)
+    /// <param name="publicOnly">Determines whether only public classes should be registered</param>
+    public static IServiceCollection AddQueries(this IServiceCollection services, IEnumerable<Assembly> assemblies, bool publicOnly = false)
     {
         services.AddSingleton<IQueryDispatcher, QueryDispatcher>();
         services.Scan(s => s.FromAssemblies(assemblies) // TODO: remove scrutor and register by own util
-            .AddClasses(c => c.AssignableTo(typeof(IQueryHandler<,>))
-                .WithoutAttribute<DecoratorAttribute>())
+            .AddClasses(
+                c => c.AssignableTo(typeof(IQueryHandler<,>))
+                    .WithoutAttribute<DecoratorAttribute>(),
+                publicOnly)
             .AsImplementedInterfaces()
             .WithScopedLifetime());
 
         services
             .Scan(s => s.FromAssemblies(assemblies)
-                .AddClasses(c => c.AssignableTo(typeof(IQueryValidator<>)))
+                .AddClasses(c => c.AssignableTo(typeof(IQueryValidator<>)), publicOnly)
                 .AsImplementedInterfaces()
                 .WithScopedLifetime());
         return services;

--- a/src/Allegro.Extensions.Cqrs/CHANGELOG.md
+++ b/src/Allegro.Extensions.Cqrs/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2025-01-14
+### Allegro.Extensions.Cqrs
+- Added publicOnly parameter to AddQueries and AddCommands methods
+- Unified commands/queries registration behavior across different Scrutor versions
+### Allegro.Extensions.Cqrs.FluentValidations
+- Added publicOnly parameter to AddCqrsFluentValidations method
+- Unified validators registration behavior across different Scrutor versions
+
 ## [2.1.0] - 2023-01-26
 
 ### Allegro.Extensions.Cqrs

--- a/src/Allegro.Extensions.Cqrs/version.xml
+++ b/src/Allegro.Extensions.Cqrs/version.xml
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/src/Allegro.Extensions.DependencyCall/Allegro.Extensions.DependencyCall/StartupExtensions.cs
+++ b/src/Allegro.Extensions.DependencyCall/Allegro.Extensions.DependencyCall/StartupExtensions.cs
@@ -12,10 +12,15 @@ public static class StartupExtensions
     /// <summary>
     /// Register dependency call abstractions and scan to register usages;
     /// </summary>
+    /// <param name="services"></param>
+    /// <param name="configureDependencyCall">An optional action to configure the dependency call builder.</param>
+    /// <param name="applicationAssemblies">An optional collection of assemblies in which dependency call types should be looked for.</param>
+    /// <param name="publicOnly">Determines whether only public classes should be registered</param>
     public static IServiceCollection AddDependencyCall(
         this IServiceCollection services,
         Action<DependencyCallBuilder>? configureDependencyCall = null,
-        IReadOnlyCollection<Assembly>? applicationAssemblies = null)
+        IReadOnlyCollection<Assembly>? applicationAssemblies = null,
+        bool publicOnly = false)
     {
         var builder = new DependencyCallBuilder(services);
         configureDependencyCall?.Invoke(builder);
@@ -26,7 +31,7 @@ public static class StartupExtensions
                 .FromAssemblies(
                     applicationAssemblies ??
                     AppDomain.CurrentDomain.GetAssemblies())
-                .AddClasses(c => c.AssignableTo(typeof(IDependencyCall<,>)))
+                .AddClasses(c => c.AssignableTo(typeof(IDependencyCall<,>)), publicOnly)
                 .AsImplementedInterfaces()// TODO: remove scrutor and register by own util
                 .WithTransientLifetime());
         return services

--- a/src/Allegro.Extensions.DependencyCall/CHANGELOG.md
+++ b/src/Allegro.Extensions.DependencyCall/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-01-14
+
+### Added
+* Added publicOnly parameter to AddDependencyCall method
+* Unified DependencyCall registration behavior across different Scrutor versions
 
 ## [1.1.0] - 2024-01-31
 

--- a/src/Allegro.Extensions.DependencyCall/version.xml
+++ b/src/Allegro.Extensions.DependencyCall/version.xml
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.1.1</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Due to the breaking change in the Scrutor library [here](https://github.com/khellang/Scrutor/pull/238), I have updated the usages of the AddClasses() method to explicitly pass the publicOnly parameter. This way library behaviour will be consistent regardless of the scrutor version used by the client.
Additionally, I have added publicOnly as an optional parameter to our API. 